### PR TITLE
Added Switch control processor operations

### DIFF
--- a/internal/operations/operations.go
+++ b/internal/operations/operations.go
@@ -34,6 +34,7 @@ import (
 
 	ospb "github.com/openconfig/gnoi/os"
 	spb "github.com/openconfig/gnoi/system"
+        "github.com/openconfig/gnoi/types"
 	opb "github.com/openconfig/ondatra/proto"
 )
 
@@ -342,4 +343,28 @@ func checkDUT(dev binding.Device, op string) (*binding.DUT, error) {
 		return nil, errors.Errorf("%s operation not supported on ATEs: %v", op, dev)
 	}
 	return dev.(*binding.DUT), nil
+}
+
+
+// SwitchControlProcessor switchs to destination route processor
+func SwitchControlProcessor(ctx context.Context, dev binding.Device, dest string) error {
+       dut, err := checkDUT(dev, "restart routing")
+       if err != nil {
+               return err
+       }
+       gnoi, err := FetchGNOI(ctx, dut)
+       if err != nil {
+              return err
+       }
+       controlProcessor := &types.Path{
+               Origin: "openconfig-platform",
+               Elem: []*types.PathElem{
+                       {Name: "components",},
+                       {Name: "component",Key: map[string]string{"name": dest}},
+                       {Name: "state"},
+                       {Name: "location"},
+               },
+       }
+       _, err = gnoi.System().SwitchControlProcessor(ctx,&spb.SwitchControlProcessorRequest{ControlProcessor:controlProcessor})
+       return err
 }

--- a/internal/operations/operations.go
+++ b/internal/operations/operations.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
+	"github.com/openconfig/gnoi/types"
 	"github.com/openconfig/ondatra/binding"
 	"github.com/openconfig/ondatra/binding/usererr"
 	"github.com/openconfig/ondatra/internal/ate"
@@ -34,7 +35,6 @@ import (
 
 	ospb "github.com/openconfig/gnoi/os"
 	spb "github.com/openconfig/gnoi/system"
-        "github.com/openconfig/gnoi/types"
 	opb "github.com/openconfig/ondatra/proto"
 )
 
@@ -346,9 +346,9 @@ func checkDUT(dev binding.Device, op string) (*binding.DUT, error) {
 }
 
 
-// SwitchControlProcessor switchs to destination route processor
+// SwitchControlProcessor switches to destination route processor.
 func SwitchControlProcessor(ctx context.Context, dev binding.Device, dest string) error {
-       dut, err := checkDUT(dev, "restart routing")
+       dut, err := checkDUT(dev, "switch control processor")
        if err != nil {
                return err
        }

--- a/operations.go
+++ b/operations.go
@@ -285,3 +285,36 @@ func (r *KillProcessOp) Operate(t testing.TB) {
 		t.Fatalf("Operate(t) on %s: %v", r, err)
 	}
 }
+
+
+// NewSwitchControlProcessor creates a new switch control processor operation.
+func (o *Operations) NewSwitchControlProcessor() *SwitchControlProcessorOp {
+	return &SwitchControlProcessorOp{
+		dev: o.dev,
+	}
+}
+
+// SwitchControlProcessorOp is an operation that switch from current route procesor
+// to provided route processor.
+type SwitchControlProcessorOp struct {
+	dev binding.Device
+	dest string
+}
+
+func (s *SwitchControlProcessorOp) String() string {
+	return fmt.Sprintf("SwitchControlProcessorOp%+v", *s)
+}
+
+// WithDestinationControlProcessor sets the destination route processor to switch to.
+func (s *SwitchControlProcessorOp) WithDestinationControlProcessor(dest string) *SwitchControlProcessorOp {
+	s.dest = dest
+	return s
+}
+
+// Operate performs the SwitchControlProcessor operation.
+func (s *SwitchControlProcessorOp) Operate(t testing.TB) {
+	t.Helper()
+	if err := operations.SwitchControlProcessor(context.Background(), s.dev, s.dest); err != nil {
+		t.Fatalf("Operate(t) on %s: %v",s.dest, err)
+	}
+}

--- a/operations.go
+++ b/operations.go
@@ -294,7 +294,7 @@ func (o *Operations) NewSwitchControlProcessor() *SwitchControlProcessorOp {
 	}
 }
 
-// SwitchControlProcessorOp is an operation that switch from current route procesor
+// SwitchControlProcessorOp is an operation that switches from current route procesor
 // to provided route processor.
 type SwitchControlProcessorOp struct {
 	dev binding.Device
@@ -305,8 +305,8 @@ func (s *SwitchControlProcessorOp) String() string {
 	return fmt.Sprintf("SwitchControlProcessorOp%+v", *s)
 }
 
-// WithDestinationControlProcessor sets the destination route processor to switch to.
-func (s *SwitchControlProcessorOp) WithDestinationControlProcessor(dest string) *SwitchControlProcessorOp {
+// WithDestinationControlProcessor sets the destination route processor.
+func (s *SwitchControlProcessorOp) WithDestination(dest string) *SwitchControlProcessorOp {
 	s.dest = dest
 	return s
 }

--- a/operations_test.go
+++ b/operations_test.go
@@ -688,8 +688,8 @@ func TestSwitchControlProcessorErrors(t *testing.T) {
 	initOperationFakes(t)
 	sw := DUT(t, "dut").Operations().NewSwitchControlProcessor()
 	fakeGNOI.SwitchController = func(ctx context.Context, in *spb.SwitchControlProcessorRequest,opts ...grpc.CallOption) (*spb.SwitchControlProcessorResponse, error) {
-		scpErr := status.Errorf(codes.InvalidArgument,"invalid route controller")
-		return &spb.SwitchControlProcessorResponse{}, scpErr
+		err := status.Errorf(codes.InvalidArgument,"invalid route controller")
+		return &spb.SwitchControlProcessorResponse{}, err
 	}
 	var op *SwitchControlProcessorOp
 	gotErr := testt.ExpectFatal(t, func(t testing.TB) {


### PR DESCRIPTION
This pull adds support for SwitchControlProcessor operation to ondatra. 

Changes include positive test cases and error test cases with mocked GNOI client. Here is the sample output of test run
ok      github.com/openconfig/ondatra   0.283s
"SwitchControlProcessor"
=== RUN   TestSwitchControlProcessor
=== RUN   TestSwitchControlProcessor/cisco_switch_control_processor
--- PASS: TestSwitchControlProcessor (0.00s)
    --- PASS: TestSwitchControlProcessor/cisco_switch_control_processor (0.00s)
=== RUN   TestSwitchControlProcessorErrors
--- PASS: TestSwitchControlProcessorErrors (0.00s)
PASS
ok      github.com/openconfig/ondatra   0.288s
