### PR TITLE
adding support for send notification operation for bgp peers

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -46,39 +46,35 @@ func (n *BGPPeerNotification) String() string {
 }
 
 // NewBGPPeerNotification returns an instance of API for sending BGP notification/error codes.
+// The returned API instance has a configuration with the following defaults:
+// code: 1
+// subCode: 1
 func (a *Actions) NewBGPPeerNotification() *BGPPeerNotification {
-	// setting the default values for the respective parameters
 	return &BGPPeerNotification{
-		ate:       a.ate,
-		code:      1,
-		subCode:   1,
-		peerNames: []string{},
+		ate:     a.ate,
+		code:    1,
+		subCode: 1,
 	}
 }
 
-// WithCode sets the notification code that needs to be sent from BGP peer.
+// WithCode sets the notification code to be sent from BGP peer.
 func (n *BGPPeerNotification) WithCode(code int) *BGPPeerNotification {
 	n.code = code
 	return n
 }
 
-// WithSubCode sets the notification sub code that needs to be sent from BGP peer.
+// WithSubCode sets the notification sub code to be sent from BGP peer.
 func (n *BGPPeerNotification) WithSubCode(subCode int) *BGPPeerNotification {
 	n.subCode = subCode
 	return n
 }
 
-// WithBGPPeers adds the BGP peers from which the notification/error codes is to be sent.
-func (n *BGPPeerNotification) WithBGPPeers(bgpPeers ...*BGPPeer) *BGPPeerNotification {
+// WithPeers adds the BGP peers from which the notification/error codes is to be sent.
+func (n *BGPPeerNotification) WithPeers(bgpPeers ...*BGPPeer) *BGPPeerNotification {
+	n.peerNames = make([]string, 0)
 	for _, bgpPeer := range bgpPeers {
-		n.peerNames = append(n.peerNames, bgpPeer.Name())
+		n.peerNames = append(n.peerNames, bgpPeer.pb.GetName())
 	}
-	return n
-}
-
-// ClearBGPPeers clears the bgp peers currently assigned.
-func (n *BGPPeerNotification) ClearBGPPeers() *BGPPeerNotification {
-	n.peerNames = n.peerNames[:0]
 	return n
 }
 

--- a/actions.go
+++ b/actions.go
@@ -1,0 +1,96 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ondatra
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/openconfig/ondatra/binding"
+	"github.com/openconfig/ondatra/internal/ate"
+)
+
+// Actions is an ATE Action API.
+type Actions struct {
+	ate binding.ATE
+}
+
+func (action *Actions) String() string {
+	return fmt.Sprintf("{ate: %s}", action.ate)
+}
+
+// BGPPeerNotification is an actions API to send BGP notification/error codes
+type BGPPeerNotification struct {
+	ate                 binding.ATE
+	notificationCode    int
+	notificationSubCode int
+	bgpPeerNames        []string
+}
+
+func (notification *BGPPeerNotification) String() string {
+	return fmt.Sprintf("{notificationCode: %d, notificationSubCode: %d, bgpPeerNames: %s}", notification.notificationCode, notification.notificationSubCode, notification.bgpPeerNames)
+}
+
+// NewBGPPeerNotification returns an instance of API for sending BGP notification/error codes
+func (action *Actions) NewBGPPeerNotification() *BGPPeerNotification {
+	// setting the default values for the respective parameters
+	return &BGPPeerNotification{
+		ate:                 action.ate,
+		notificationCode:    1,
+		notificationSubCode: 1,
+		bgpPeerNames:        []string{},
+	}
+}
+
+// WithNotificationCode Sets the notification code that needs to be sent from BGP peer
+func (notification *BGPPeerNotification) WithNotificationCode(code int) *BGPPeerNotification {
+	notification.notificationCode = code
+	return notification
+}
+
+// WithNotificationSubCode Sets the notification sub code that needs to be sent from BGP peer
+func (notification *BGPPeerNotification) WithNotificationSubCode(subCode int) *BGPPeerNotification {
+	notification.notificationSubCode = subCode
+	return notification
+}
+
+// WithBGPPeers adds the BGP peers from which the notification/error codes is to be sent
+func (notification *BGPPeerNotification) WithBGPPeers(bgpPeers ...*BGPPeer) *BGPPeerNotification {
+	for _, bgpPeer := range bgpPeers {
+		notification.bgpPeerNames = append(notification.bgpPeerNames, bgpPeer.FetchName())
+	}
+	return notification
+}
+
+// ClearBGPPeers clears the bgp peers currently assigned
+func (notification *BGPPeerNotification) ClearBGPPeers() *BGPPeerNotification {
+	notification.bgpPeerNames = notification.bgpPeerNames[:0]
+	return notification
+}
+
+// Send executes the operation to send notification/error codes
+func (notification *BGPPeerNotification) Send(t testing.TB) {
+	t.Helper()
+
+	if len(notification.bgpPeerNames) == 0 {
+		t.Fatalf("Send(t) on %s: no bgp peer provided", notification)
+	}
+
+	if err := ate.SendBGPPeerNotification(context.Background(), notification.ate, notification.notificationCode, notification.notificationSubCode, notification.bgpPeerNames); err != nil {
+		t.Fatalf("Send(t) failed with parameters %d, %d, %s on %s: %v", notification.notificationCode, notification.notificationSubCode, notification.bgpPeerNames, notification, err)
+	}
+}

--- a/actions.go
+++ b/actions.go
@@ -29,68 +29,63 @@ type Actions struct {
 	ate binding.ATE
 }
 
-func (action *Actions) String() string {
-	return fmt.Sprintf("{ate: %s}", action.ate)
+func (a *Actions) String() string {
+	return fmt.Sprintf("Actions%+v", *a)
 }
 
-// BGPPeerNotification is an actions API to send BGP notification/error codes
+// BGPPeerNotification is an actions API to send BGP notification/error codes.
 type BGPPeerNotification struct {
-	ate                 binding.ATE
-	notificationCode    int
-	notificationSubCode int
-	bgpPeerNames        []string
+	ate       binding.ATE
+	code      int
+	subCode   int
+	peerNames []string
 }
 
-func (notification *BGPPeerNotification) String() string {
-	return fmt.Sprintf("{notificationCode: %d, notificationSubCode: %d, bgpPeerNames: %s}", notification.notificationCode, notification.notificationSubCode, notification.bgpPeerNames)
+func (n *BGPPeerNotification) String() string {
+	return fmt.Sprintf("BGPPeerNotification%+v", *n)
 }
 
-// NewBGPPeerNotification returns an instance of API for sending BGP notification/error codes
-func (action *Actions) NewBGPPeerNotification() *BGPPeerNotification {
+// NewBGPPeerNotification returns an instance of API for sending BGP notification/error codes.
+func (a *Actions) NewBGPPeerNotification() *BGPPeerNotification {
 	// setting the default values for the respective parameters
 	return &BGPPeerNotification{
-		ate:                 action.ate,
-		notificationCode:    1,
-		notificationSubCode: 1,
-		bgpPeerNames:        []string{},
+		ate:       a.ate,
+		code:      1,
+		subCode:   1,
+		peerNames: []string{},
 	}
 }
 
-// WithNotificationCode Sets the notification code that needs to be sent from BGP peer
-func (notification *BGPPeerNotification) WithNotificationCode(code int) *BGPPeerNotification {
-	notification.notificationCode = code
-	return notification
+// WithCode sets the notification code that needs to be sent from BGP peer.
+func (n *BGPPeerNotification) WithCode(code int) *BGPPeerNotification {
+	n.code = code
+	return n
 }
 
-// WithNotificationSubCode Sets the notification sub code that needs to be sent from BGP peer
-func (notification *BGPPeerNotification) WithNotificationSubCode(subCode int) *BGPPeerNotification {
-	notification.notificationSubCode = subCode
-	return notification
+// WithSubCode sets the notification sub code that needs to be sent from BGP peer.
+func (n *BGPPeerNotification) WithSubCode(subCode int) *BGPPeerNotification {
+	n.subCode = subCode
+	return n
 }
 
-// WithBGPPeers adds the BGP peers from which the notification/error codes is to be sent
-func (notification *BGPPeerNotification) WithBGPPeers(bgpPeers ...*BGPPeer) *BGPPeerNotification {
+// WithBGPPeers adds the BGP peers from which the notification/error codes is to be sent.
+func (n *BGPPeerNotification) WithBGPPeers(bgpPeers ...*BGPPeer) *BGPPeerNotification {
 	for _, bgpPeer := range bgpPeers {
-		notification.bgpPeerNames = append(notification.bgpPeerNames, bgpPeer.FetchName())
+		n.peerNames = append(n.peerNames, bgpPeer.Name())
 	}
-	return notification
+	return n
 }
 
-// ClearBGPPeers clears the bgp peers currently assigned
-func (notification *BGPPeerNotification) ClearBGPPeers() *BGPPeerNotification {
-	notification.bgpPeerNames = notification.bgpPeerNames[:0]
-	return notification
+// ClearBGPPeers clears the bgp peers currently assigned.
+func (n *BGPPeerNotification) ClearBGPPeers() *BGPPeerNotification {
+	n.peerNames = n.peerNames[:0]
+	return n
 }
 
-// Send executes the operation to send notification/error codes
-func (notification *BGPPeerNotification) Send(t testing.TB) {
+// Send executes the operation to send notification/error codes.
+func (n *BGPPeerNotification) Send(t testing.TB) {
 	t.Helper()
-
-	if len(notification.bgpPeerNames) == 0 {
-		t.Fatalf("Send(t) on %s: no bgp peer provided", notification)
-	}
-
-	if err := ate.SendBGPPeerNotification(context.Background(), notification.ate, notification.notificationCode, notification.notificationSubCode, notification.bgpPeerNames); err != nil {
-		t.Fatalf("Send(t) failed with parameters %d, %d, %s on %s: %v", notification.notificationCode, notification.notificationSubCode, notification.bgpPeerNames, notification, err)
+	if err := ate.SendBGPPeerNotification(context.Background(), n.ate, n.code, n.subCode, n.peerNames); err != nil {
+		t.Fatalf("Send(t) failed on %s: %v", n, err)
 	}
 }

--- a/ate.go
+++ b/ate.go
@@ -41,3 +41,8 @@ func (a *ATEDevice) Topology() *Topology {
 func (a *ATEDevice) Traffic() *Traffic {
 	return &Traffic{a.res.(binding.ATE)}
 }
+
+// Actions returns a handle to the various Action APIs
+func (a *ATEDevice) Actions() *Actions {
+	return &Actions{a.res.(binding.ATE)}
+}

--- a/ate.go
+++ b/ate.go
@@ -42,7 +42,7 @@ func (a *ATEDevice) Traffic() *Traffic {
 	return &Traffic{a.res.(binding.ATE)}
 }
 
-// Actions returns a handle to the various Action APIs
+// Actions returns a handle to the Actions API.
 func (a *ATEDevice) Actions() *Actions {
 	return &Actions{a.res.(binding.ATE)}
 }

--- a/bgp.go
+++ b/bgp.go
@@ -76,11 +76,6 @@ func (b *BGPPeer) WithName(name string) *BGPPeer {
 	return b
 }
 
-// Name returns the name of the peer.
-func (b *BGPPeer) Name() string {
-	return b.pb.GetName()
-}
-
 // WithActive sets whether the peering is active.
 func (b *BGPPeer) WithActive(active bool) *BGPPeer {
 	b.pb.Active = active

--- a/bgp.go
+++ b/bgp.go
@@ -76,8 +76,8 @@ func (b *BGPPeer) WithName(name string) *BGPPeer {
 	return b
 }
 
-//FetchName gets the name of the peer
-func (b *BGPPeer) FetchName() string {
+// Name returns the name of the peer.
+func (b *BGPPeer) Name() string {
 	return b.pb.GetName()
 }
 

--- a/bgp.go
+++ b/bgp.go
@@ -70,6 +70,17 @@ func (b *BGP) ClearPeers() *BGP {
 	return b
 }
 
+// WithName sets name for the peer.
+func (b *BGPPeer) WithName(name string) *BGPPeer {
+	b.pb.Name = name
+	return b
+}
+
+//FetchName gets the name of the peer
+func (b *BGPPeer) FetchName() string {
+	return b.pb.GetName()
+}
+
 // WithActive sets whether the peering is active.
 func (b *BGPPeer) WithActive(active bool) *BGPPeer {
 	b.pb.Active = active

--- a/internal/ate/ate.go
+++ b/internal/ate/ate.go
@@ -88,6 +88,18 @@ func UpdateTopology(ctx context.Context, ate binding.ATE, top *Topology, bgpPeer
 	return nil
 }
 
+// SendNotification sends a notification/error message on an ATE.
+func SendBGPPeerNotification(ctx context.Context, ate binding.ATE, notificationCode int, notificationSubCode int, bgpPeers []string) error {
+	ix, err := ixiaForATE(ctx, ate)
+	if err != nil {
+		return err
+	}
+	if err := ix.SendBGPPeerNotification(ctx, notificationCode, notificationSubCode, bgpPeers); err != nil {
+		return fmt.Errorf("failed to send notification: %w", err)
+	}
+	return nil
+}
+
 // UpdateNetworks updates network groups in a topology on an ATE on the fly.
 func UpdateNetworks(ctx context.Context, ate binding.ATE, top *Topology) error {
 	ix, err := ixiaForATE(ctx, ate)

--- a/internal/ate/ate.go
+++ b/internal/ate/ate.go
@@ -88,13 +88,13 @@ func UpdateTopology(ctx context.Context, ate binding.ATE, top *Topology, bgpPeer
 	return nil
 }
 
-// SendNotification sends a notification/error message on an ATE.
-func SendBGPPeerNotification(ctx context.Context, ate binding.ATE, notificationCode int, notificationSubCode int, bgpPeers []string) error {
+// SendBGPPeerNotification sends a notification/error message on an ATE.
+func SendBGPPeerNotification(ctx context.Context, ate binding.ATE, code int, subCode int, peerNames []string) error {
 	ix, err := ixiaForATE(ctx, ate)
 	if err != nil {
 		return err
 	}
-	if err := ix.SendBGPPeerNotification(ctx, notificationCode, notificationSubCode, bgpPeers); err != nil {
+	if err := ix.SendBGPPeerNotification(ctx, code, subCode, peerNames); err != nil {
 		return fmt.Errorf("failed to send notification: %w", err)
 	}
 	return nil

--- a/internal/ate/ixate.go
+++ b/internal/ate/ixate.go
@@ -1382,11 +1382,16 @@ func validateIP(ipc *opb.IpConfig, desc string) error {
 	return nil
 }
 
-// sends notification/error messages from bgp peers on ATE
-func (ix *ixATE) SendBGPPeerNotification(ctx context.Context, notificationCode int, notificationSubCode int, bgp []string) error {
+// sends notification/error messages from bgp peers on ATE.
+func (ix *ixATE) SendBGPPeerNotification(ctx context.Context, code int, subCode int, peerNames []string) error {
+
+	if len(peerNames) == 0 {
+		return fmt.Errorf("no bgp peer provided")
+	}
+
 	var cfgNodes []ixconfig.IxiaCfgNode
 	for _, intf := range ix.intfs {
-		for _, bgpName := range bgp {
+		for _, bgpName := range peerNames {
 			if val, ok := intf.bgpToBgpIpv4Peer[bgpName]; ok {
 				cfgNodes = append(cfgNodes, val)
 			}
@@ -1415,8 +1420,8 @@ func (ix *ixATE) SendBGPPeerNotification(ctx context.Context, notificationCode i
 		breakTcpSessionArgs := ixweb.OpArgs{
 			nodeHerf,
 			[]int{1},
-			notificationCode,
-			notificationSubCode,
+			code,
+			subCode,
 		}
 		if err := ix.c.Session().Post(ctx, breakTcpSessionOp, breakTcpSessionArgs, nil); err != nil {
 			return fmt.Errorf("could not send bgp notification %w", err)

--- a/internal/ate/protocols.go
+++ b/internal/ate/protocols.go
@@ -876,6 +876,11 @@ func (ix *ixATE) addBGPProtocols(ifc *opb.InterfaceConfig) error {
 			return err
 		}
 		intf.ipv4.BgpIpv4Peer = peers
+		intf.bgpToBgpIpv4Peer = make(map[string]*ixconfig.TopologyBgpIpv4Peer)
+		for i, bgpv4Peer := range peers {
+			intf.bgpToBgpIpv4Peer[v4Peers[i].GetName()] = bgpv4Peer
+		}
+
 	}
 	if len(v6Peers) > 0 {
 		if intf.ipv6 == nil {
@@ -886,6 +891,10 @@ func (ix *ixATE) addBGPProtocols(ifc *opb.InterfaceConfig) error {
 			return err
 		}
 		intf.ipv6.BgpIpv6Peer = peers
+		intf.bgpToBgpIpv6Peer = make(map[string]*ixconfig.TopologyBgpIpv6Peer)
+		for i, bgpv6Peer := range peers {
+			intf.bgpToBgpIpv6Peer[v6Peers[i].GetName()] = bgpv6Peer
+		}
 	}
 	if len(v4LoopbackPeers) > 0 {
 		if intf.ipv4Loopback == nil {

--- a/proto/ate.proto
+++ b/proto/ate.proto
@@ -374,7 +374,8 @@ message BgpPeer {
     Enlp enlp = 13;
   }
   repeated SrtePolicyGroup srte_policy_groups = 9;
-  // NEXT ID: 11
+  string name = 11;
+  // NEXT ID: 12
 }
 
 // BGP attributes for advertised prefixes.

--- a/topology.go
+++ b/topology.go
@@ -123,6 +123,18 @@ func (at *ATETopology) UpdateBGPPeerStates(t testing.TB) {
 	}
 }
 
+// SendBgpPeerNotification is used for sending notification messages/error codes from bgp peers to DUT
+func (at *ATETopology) SendBgpPeerNotification(t testing.TB, notificationCode int, notificationSubCode int, bgpPeers ...*BGPPeer) {
+	t.Helper()
+	var bgpPeerNames []string
+	for _, bgpPeer := range bgpPeers {
+		bgpPeerNames = append(bgpPeerNames, bgpPeer.FetchName())
+	}
+	if err := ate.SendBGPPeerNotification(context.Background(), at.ate, notificationCode, notificationSubCode, bgpPeerNames); err != nil {
+		t.Fatalf("SendBgpPeerNotification(t, %d, %d, %v) on %s: %v", notificationCode, notificationSubCode, bgpPeers, at, err)
+	}
+}
+
 // UpdateNetworks is equivalent to Update() but only updates the Network config on the fly.
 func (at *ATETopology) UpdateNetworks(t testing.TB) {
 	t.Helper()

--- a/topology.go
+++ b/topology.go
@@ -123,18 +123,6 @@ func (at *ATETopology) UpdateBGPPeerStates(t testing.TB) {
 	}
 }
 
-// SendBgpPeerNotification is used for sending notification messages/error codes from bgp peers to DUT
-func (at *ATETopology) SendBgpPeerNotification(t testing.TB, notificationCode int, notificationSubCode int, bgpPeers ...*BGPPeer) {
-	t.Helper()
-	var bgpPeerNames []string
-	for _, bgpPeer := range bgpPeers {
-		bgpPeerNames = append(bgpPeerNames, bgpPeer.FetchName())
-	}
-	if err := ate.SendBGPPeerNotification(context.Background(), at.ate, notificationCode, notificationSubCode, bgpPeerNames); err != nil {
-		t.Fatalf("SendBgpPeerNotification(t, %d, %d, %v) on %s: %v", notificationCode, notificationSubCode, bgpPeers, at, err)
-	}
-}
-
 // UpdateNetworks is equivalent to Update() but only updates the Network config on the fly.
 func (at *ATETopology) UpdateNetworks(t testing.TB) {
 	t.Helper()


### PR DESCRIPTION
This pull request is regarding the issue #14 
The changes include:
1. exposing the name property in the ate.proto for bgp peer
2. bgp.go file will have function to get and set name of bgp peer
3. changes in ixate.go to maintain a map of name and bgp peers 
4. implementation of the send notification operation.

Example Test-Case
```go
top := ate.Topology().New()
port := ate.Port(t, "por1")
in := top.AddInterface("ateSrc").WithPort(port)
in.IPv6().WithAddress("2000:0:0:1::b/64").WithDefaultGateway("2000:0:0:1::1")
bgp := i3.BGP().AddPeer().WithName("bgpv61")
bgp.WithPeerAddress("2000:0:0:1::1").WithTypeInternal().WithLocalASN(22)
top.Push(t).StartProtocols(t)
// for sending cease error code
top.SendBgpPeerNotification(t, 6, 1, bgp)
```