### PR TITLE
Support of IPv4 Packet Header

### DIFF
--- a/headers.go
+++ b/headers.go
@@ -201,12 +201,6 @@ func (h *IPv4Header) WithIdentification(identification uint16) *IPv4Header {
 	return h
 }
 
-// WithReserved set flag 0 bit of IPv4 Header
-func (h *IPv4Header) WithReserved(reserved bool) *IPv4Header {
-	h.pb.Reserved = reserved
-	return h
-}
-
 // WithMoreFragments set flag 2 bit for more fragments of IPv4 Header
 func (h *IPv4Header) WithMoreFragments(moreFragments bool) *IPv4Header {
 	h.pb.MoreFragments = moreFragments

--- a/headers.go
+++ b/headers.go
@@ -189,6 +189,50 @@ func (h *IPv4Header) WithHeaderChecksum(checksum uint16) *IPv4Header {
 	return h
 }
 
+// WithHeaderLength set IP header length
+func (h *IPv4Header) WithHeaderLength(headerLength uint8) *IPv4Header {
+	h.pb.HeaderLength = uint32(headerLength)
+	return h
+}
+
+// WithProtocol set Name of the protocol to which the data is to be passed
+func (h *IPv4Header) WithProtocol(protocol uint8) *IPv4Header {
+	h.pb.Protocol = intRangeSingle(uint32(protocol))
+	return h
+}
+
+// WithTotalLength set size of the entire datagram. 
+// The minimum size of an IP datagram is 20 bytes, and at the maximum, it can be 65,535 bytes.
+func (h *IPv4Header) WithTotalLength(totalLength uint16) *IPv4Header {
+	h.pb.TotalLength = uint32(totalLength)
+	return h
+}
+
+// WithIdentification set identification or ID field of IPv4 Header
+func (h *IPv4Header) WithIdentification(identification bool) *IPv4Header {
+	h.pb.Identification = identification
+	return h
+}
+
+// WithReserved set flag 0 bit of IPv4 Header
+func (h *IPv4Header) WithReserved(reserved bool) *IPv4Header {
+	h.pb.Reserved = reserved
+	return h
+}
+
+// WithMoreFragments set flag 2 bit for more fragments of IPv4 Header
+func (h *IPv4Header) WithMoreFragments(moreFragments bool) *IPv4Header {
+	h.pb.MoreFragments = moreFragments
+	return h
+}
+
+// WithFragmentOffset set number of Data Bytes in Datagram. 
+// It ranges from 8 bytes to 65,528 bytes
+func (h *IPv4Header) WithFragmentOffset(fragmentOffset uint16) *IPv4Header {
+	h.pb.FragmentOffset = intRangeSingle(uint32(fragmentOffset))
+	return h
+}
+
 func (h *IPv4Header) asPB() *opb.Header {
 	return &opb.Header{Type: &opb.Header_Ipv4{h.pb}}
 }

--- a/headers.go
+++ b/headers.go
@@ -189,28 +189,15 @@ func (h *IPv4Header) WithHeaderChecksum(checksum uint16) *IPv4Header {
 	return h
 }
 
-// WithHeaderLength set IP header length
-func (h *IPv4Header) WithHeaderLength(headerLength uint8) *IPv4Header {
-	h.pb.HeaderLength = uint32(headerLength)
-	return h
-}
-
 // WithProtocol set Name of the protocol to which the data is to be passed
 func (h *IPv4Header) WithProtocol(protocol uint8) *IPv4Header {
 	h.pb.Protocol = intRangeSingle(uint32(protocol))
 	return h
 }
 
-// WithTotalLength set size of the entire datagram. 
-// The minimum size of an IP datagram is 20 bytes, and at the maximum, it can be 65,535 bytes.
-func (h *IPv4Header) WithTotalLength(totalLength uint16) *IPv4Header {
-	h.pb.TotalLength = uint32(totalLength)
-	return h
-}
-
 // WithIdentification set identification or ID field of IPv4 Header
-func (h *IPv4Header) WithIdentification(identification bool) *IPv4Header {
-	h.pb.Identification = identification
+func (h *IPv4Header) WithIdentification(identification uint16) *IPv4Header {
+	h.pb.Identification = uint32(identification)
 	return h
 }
 
@@ -229,7 +216,7 @@ func (h *IPv4Header) WithMoreFragments(moreFragments bool) *IPv4Header {
 // WithFragmentOffset set number of Data Bytes in Datagram. 
 // It ranges from 8 bytes to 65,528 bytes
 func (h *IPv4Header) WithFragmentOffset(fragmentOffset uint16) *IPv4Header {
-	h.pb.FragmentOffset = intRangeSingle(uint32(fragmentOffset))
+	h.pb.FragmentOffset = uint32(fragmentOffset)
 	return h
 }
 

--- a/internal/ate/stacks.go
+++ b/internal/ate/stacks.go
@@ -160,10 +160,6 @@ func ipv4Stack(ipv4 *opb.Ipv4Header, idx int) (*ixconfig.TrafficTrafficItemConfi
 	if ipv4.GetDontFragment() {
 		dontFragment = 1
 	}
-	var identification uint32
-	if ipv4.GetIdentification() {
-		identification = 1
-	}
 	var reserved uint32
 	if ipv4.GetReserved() {
 		reserved = 1
@@ -172,27 +168,17 @@ func ipv4Stack(ipv4 *opb.Ipv4Header, idx int) (*ixconfig.TrafficTrafficItemConfi
 	if ipv4.GetMoreFragments() {
 		moreFragments = 1
 	}
-	setSingleValue(stack.Identification(), uintToStr(identification))
+	setSingleValue(stack.Identification(), uintToStr(ipv4.GetIdentification()))
 	setSingleValue(stack.FlagsReserved(), uintToStr(reserved))
 	setSingleValue(stack.FlagsFragment(), uintToStr(dontFragment))
 	setSingleValue(stack.FlagsLastFragment(), uintToStr(moreFragments))
 	setSingleValue(stack.Ttl(), uintToStr(ipv4.GetTtl()))
-	if ipv4.GetHeaderLength() > 0 {
-		setSingleValue(stack.HeaderLength(), uintToStr(ipv4.GetHeaderLength()))
-	}
 	if ipv4.GetProtocol() != nil {
 		if err := setUintRangeField(stack.Protocol(), ipv4.GetProtocol()); err != nil {
 			return nil, fmt.Errorf("could not set Ipv4 Protocol: %w", err)
 		}
 	}
-	if ipv4.GetTotalLength() > 0 {
-		setSingleValue(stack.TotalLength(), uintToStr(ipv4.GetTotalLength()))
-	}
-	if ipv4.GetFragmentOffset() != nil {
-		if err := setUintRangeField(stack.FragmentOffset(), ipv4.GetFragmentOffset()); err != nil {
-			return nil, fmt.Errorf("could not set Ipv4 FragmentOffset: %w", err)
-		}
-	}
+	setSingleValue(stack.FragmentOffset(), uintToStr(ipv4.GetFragmentOffset()))
 	if ipv4.GetChecksum() > 0 {
 		setSingleValue(stack.Checksum(), uintToHexStr(ipv4.GetChecksum()))
 	}

--- a/internal/ate/stacks.go
+++ b/internal/ate/stacks.go
@@ -160,16 +160,11 @@ func ipv4Stack(ipv4 *opb.Ipv4Header, idx int) (*ixconfig.TrafficTrafficItemConfi
 	if ipv4.GetDontFragment() {
 		dontFragment = 1
 	}
-	var reserved uint32
-	if ipv4.GetReserved() {
-		reserved = 1
-	}
 	var moreFragments uint32
 	if ipv4.GetMoreFragments() {
 		moreFragments = 1
 	}
 	setSingleValue(stack.Identification(), uintToStr(ipv4.GetIdentification()))
-	setSingleValue(stack.FlagsReserved(), uintToStr(reserved))
 	setSingleValue(stack.FlagsFragment(), uintToStr(dontFragment))
 	setSingleValue(stack.FlagsLastFragment(), uintToStr(moreFragments))
 	setSingleValue(stack.Ttl(), uintToStr(ipv4.GetTtl()))

--- a/internal/ate/stacks.go
+++ b/internal/ate/stacks.go
@@ -160,8 +160,39 @@ func ipv4Stack(ipv4 *opb.Ipv4Header, idx int) (*ixconfig.TrafficTrafficItemConfi
 	if ipv4.GetDontFragment() {
 		dontFragment = 1
 	}
+	var identification uint32
+	if ipv4.GetIdentification() {
+		identification = 1
+	}
+	var reserved uint32
+	if ipv4.GetReserved() {
+		reserved = 1
+	}
+	var moreFragments uint32
+	if ipv4.GetMoreFragments() {
+		moreFragments = 1
+	}
+	setSingleValue(stack.Identification(), uintToStr(identification))
+	setSingleValue(stack.FlagsReserved(), uintToStr(reserved))
 	setSingleValue(stack.FlagsFragment(), uintToStr(dontFragment))
+	setSingleValue(stack.FlagsLastFragment(), uintToStr(moreFragments))
 	setSingleValue(stack.Ttl(), uintToStr(ipv4.GetTtl()))
+	if ipv4.GetHeaderLength() > 0 {
+		setSingleValue(stack.HeaderLength(), uintToStr(ipv4.GetHeaderLength()))
+	}
+	if ipv4.GetProtocol() != nil {
+		if err := setUintRangeField(stack.Protocol(), ipv4.GetProtocol()); err != nil {
+			return nil, fmt.Errorf("could not set Ipv4 Protocol: %w", err)
+		}
+	}
+	if ipv4.GetTotalLength() > 0 {
+		setSingleValue(stack.TotalLength(), uintToStr(ipv4.GetTotalLength()))
+	}
+	if ipv4.GetFragmentOffset() != nil {
+		if err := setUintRangeField(stack.FragmentOffset(), ipv4.GetFragmentOffset()); err != nil {
+			return nil, fmt.Errorf("could not set Ipv4 FragmentOffset: %w", err)
+		}
+	}
 	if ipv4.GetChecksum() > 0 {
 		setSingleValue(stack.Checksum(), uintToHexStr(ipv4.GetChecksum()))
 	}

--- a/internal/ate/stacks_test.go
+++ b/internal/ate/stacks_test.go
@@ -197,7 +197,6 @@ func TestHeaderStacks(t *testing.T) {
 					Checksum:     checksum,
 					Protocol: &opb.UIntRange{Min: protocol, Max: protocol, Count: 1},
 					Identification: identification,
-					Reserved: true,
 					MoreFragments: true,
 					FragmentOffset: fragmentOffset,
 				},
@@ -259,13 +258,6 @@ func TestHeaderStacks(t *testing.T) {
 				toField: func(s *ixconfig.TrafficTrafficItemConfigElementStack) *ixconfig.TrafficTrafficItemConfigElementStackField {
 					ip := ixconfig.Ipv4Stack(*s)
 					return (&ip).Identification()
-				},
-			}, {
-				name:    "flag reserved",
-				wantVal: ixconfig.String("1"),
-				toField: func(s *ixconfig.TrafficTrafficItemConfigElementStack) *ixconfig.TrafficTrafficItemConfigElementStackField {
-					ip := ixconfig.Ipv4Stack(*s)
-					return (&ip).FlagsReserved()
 				},
 			}, {
 				name:    "flag last fragment",

--- a/internal/ate/stacks_test.go
+++ b/internal/ate/stacks_test.go
@@ -43,9 +43,8 @@ func TestHeaderStacks(t *testing.T) {
 		dstIpv4Addr = "4.3.2.1"
 		ttl         = 64
 		checksum    = 65376
-		headerLength = 6
+		identification = 6
 		protocol = 6
-		totalLength = 200
 		fragmentOffset = 8
 		srcIpv6Addr = "1:2:3:4:5:6:7:8"
 		dstIpv6Addr = "8:7:6:5:4:3:2:1"
@@ -196,13 +195,11 @@ func TestHeaderStacks(t *testing.T) {
 					DontFragment: true,
 					Ttl:          ttl,
 					Checksum:     checksum,
-					HeaderLength: headerLength,
 					Protocol: &opb.UIntRange{Min: protocol, Max: protocol, Count: 1},
-					TotalLength: totalLength,
-					Identification: true,
+					Identification: identification,
 					Reserved: true,
 					MoreFragments: true,
-					FragmentOffset: &opb.UIntRange{Min: fragmentOffset, Max: fragmentOffset, Count: 1},
+					FragmentOffset: fragmentOffset,
 				},
 			},
 		},
@@ -250,13 +247,6 @@ func TestHeaderStacks(t *testing.T) {
 					return (&ip).DstIp()
 				},
 			}, {
-				name:    "header length",
-				wantVal: ixconfig.String(strconv.Itoa(headerLength)),
-				toField: func(s *ixconfig.TrafficTrafficItemConfigElementStack) *ixconfig.TrafficTrafficItemConfigElementStackField {
-					ip := ixconfig.Ipv4Stack(*s)
-					return (&ip).HeaderLength()
-				},	
-			}, {
 				name:    "protocol",
 				wantVal: ixconfig.String(strconv.Itoa(protocol)),
 				toField: func(s *ixconfig.TrafficTrafficItemConfigElementStack) *ixconfig.TrafficTrafficItemConfigElementStackField {
@@ -264,15 +254,8 @@ func TestHeaderStacks(t *testing.T) {
 					return (&ip).Protocol()
 				},	
 			}, {
-				name:    "total length",
-				wantVal: ixconfig.String(strconv.Itoa(totalLength)),
-				toField: func(s *ixconfig.TrafficTrafficItemConfigElementStack) *ixconfig.TrafficTrafficItemConfigElementStackField {
-					ip := ixconfig.Ipv4Stack(*s)
-					return (&ip).TotalLength()
-				},	
-			}, {
 				name:    "identification",
-				wantVal: ixconfig.String("1"),
+				wantVal: ixconfig.String(strconv.Itoa(identification)),
 				toField: func(s *ixconfig.TrafficTrafficItemConfigElementStack) *ixconfig.TrafficTrafficItemConfigElementStackField {
 					ip := ixconfig.Ipv4Stack(*s)
 					return (&ip).Identification()
@@ -285,7 +268,7 @@ func TestHeaderStacks(t *testing.T) {
 					return (&ip).FlagsReserved()
 				},
 			}, {
-				name:    "flag reserved",
+				name:    "flag last fragment",
 				wantVal: ixconfig.String("1"),
 				toField: func(s *ixconfig.TrafficTrafficItemConfigElementStack) *ixconfig.TrafficTrafficItemConfigElementStackField {
 					ip := ixconfig.Ipv4Stack(*s)

--- a/internal/ate/stacks_test.go
+++ b/internal/ate/stacks_test.go
@@ -43,6 +43,10 @@ func TestHeaderStacks(t *testing.T) {
 		dstIpv4Addr = "4.3.2.1"
 		ttl         = 64
 		checksum    = 65376
+		headerLength = 6
+		protocol = 6
+		totalLength = 200
+		fragmentOffset = 8
 		srcIpv6Addr = "1:2:3:4:5:6:7:8"
 		dstIpv6Addr = "8:7:6:5:4:3:2:1"
 		hopLimit    = 64
@@ -192,6 +196,13 @@ func TestHeaderStacks(t *testing.T) {
 					DontFragment: true,
 					Ttl:          ttl,
 					Checksum:     checksum,
+					HeaderLength: headerLength,
+					Protocol: &opb.UIntRange{Min: protocol, Max: protocol, Count: 1},
+					TotalLength: totalLength,
+					Identification: true,
+					Reserved: true,
+					MoreFragments: true,
+					FragmentOffset: &opb.UIntRange{Min: fragmentOffset, Max: fragmentOffset, Count: 1},
 				},
 			},
 		},
@@ -238,6 +249,55 @@ func TestHeaderStacks(t *testing.T) {
 					ip := ixconfig.Ipv4Stack(*s)
 					return (&ip).DstIp()
 				},
+			}, {
+				name:    "header length",
+				wantVal: ixconfig.String(strconv.Itoa(headerLength)),
+				toField: func(s *ixconfig.TrafficTrafficItemConfigElementStack) *ixconfig.TrafficTrafficItemConfigElementStackField {
+					ip := ixconfig.Ipv4Stack(*s)
+					return (&ip).HeaderLength()
+				},	
+			}, {
+				name:    "protocol",
+				wantVal: ixconfig.String(strconv.Itoa(protocol)),
+				toField: func(s *ixconfig.TrafficTrafficItemConfigElementStack) *ixconfig.TrafficTrafficItemConfigElementStackField {
+					ip := ixconfig.Ipv4Stack(*s)
+					return (&ip).Protocol()
+				},	
+			}, {
+				name:    "total length",
+				wantVal: ixconfig.String(strconv.Itoa(totalLength)),
+				toField: func(s *ixconfig.TrafficTrafficItemConfigElementStack) *ixconfig.TrafficTrafficItemConfigElementStackField {
+					ip := ixconfig.Ipv4Stack(*s)
+					return (&ip).TotalLength()
+				},	
+			}, {
+				name:    "identification",
+				wantVal: ixconfig.String("1"),
+				toField: func(s *ixconfig.TrafficTrafficItemConfigElementStack) *ixconfig.TrafficTrafficItemConfigElementStackField {
+					ip := ixconfig.Ipv4Stack(*s)
+					return (&ip).Identification()
+				},
+			}, {
+				name:    "flag reserved",
+				wantVal: ixconfig.String("1"),
+				toField: func(s *ixconfig.TrafficTrafficItemConfigElementStack) *ixconfig.TrafficTrafficItemConfigElementStackField {
+					ip := ixconfig.Ipv4Stack(*s)
+					return (&ip).FlagsReserved()
+				},
+			}, {
+				name:    "flag reserved",
+				wantVal: ixconfig.String("1"),
+				toField: func(s *ixconfig.TrafficTrafficItemConfigElementStack) *ixconfig.TrafficTrafficItemConfigElementStackField {
+					ip := ixconfig.Ipv4Stack(*s)
+					return (&ip).FlagsLastFragment()
+				},
+			}, {
+				name:    "fragment offset",
+				wantVal: ixconfig.String(strconv.Itoa(fragmentOffset)),
+				toField: func(s *ixconfig.TrafficTrafficItemConfigElementStack) *ixconfig.TrafficTrafficItemConfigElementStackField {
+					ip := ixconfig.Ipv4Stack(*s)
+					return (&ip).FragmentOffset()
+				},	
 			}},
 		},
 	}, {

--- a/proto/ate.proto
+++ b/proto/ate.proto
@@ -643,13 +643,11 @@ message Ipv4Header {
   uint32 dscp = 4;
   uint32 ecn = 5;
   uint32 checksum = 7;
-  uint32 header_length = 8;
-  UIntRange protocol = 9;
-  uint32 total_length = 10;
-  bool identification = 11;
-  bool reserved = 12;
-  bool more_fragments = 13;
-  UIntRange fragment_offset = 14;
+  UIntRange protocol = 8;
+  uint32 identification = 9;
+  bool reserved = 10;
+  bool more_fragments = 11;
+  uint32 fragment_offset = 12;
 }
 
 message Ipv6Header {

--- a/proto/ate.proto
+++ b/proto/ate.proto
@@ -645,9 +645,8 @@ message Ipv4Header {
   uint32 checksum = 7;
   UIntRange protocol = 8;
   uint32 identification = 9;
-  bool reserved = 10;
-  bool more_fragments = 11;
-  uint32 fragment_offset = 12;
+  bool more_fragments = 10;
+  uint32 fragment_offset = 11;
 }
 
 message Ipv6Header {

--- a/proto/ate.proto
+++ b/proto/ate.proto
@@ -643,6 +643,13 @@ message Ipv4Header {
   uint32 dscp = 4;
   uint32 ecn = 5;
   uint32 checksum = 7;
+  uint32 header_length = 8;
+  UIntRange protocol = 9;
+  uint32 total_length = 10;
+  bool identification = 11;
+  bool reserved = 12;
+  bool more_fragments = 13;
+  UIntRange fragment_offset = 14;
 }
 
 message Ipv6Header {


### PR DESCRIPTION
This should address issue https://github.com/openconfig/ondatra/issues/16

This is a sample code snippet when automate it from  [featureprofiles](https://github.com/openconfig/featureprofiles)

```go
func configureATE(t *testing.T, ate *ondatra.ATEDevice, atePorts []*ondatra.Port) {
	top := ate.Topology().New()
	ethHeader := ondatra.NewEthernetHeader()
	// Newly added IPv4 Header fields
	ipv4Header := ondatra.NewIPv4Header().WithProtocol(94).WithIdentification(true).WithReserved(true).WithMoreFragments(true).WithTotalLength(44).WithFragmentOffset(8)
	p1 := ate.Port(t, "port1")
	i1 := top.AddInterface("ateSrc").WithPort(p1)
	i1.IPv4().WithAddress("100.1.0.1/24").WithDefaultGateway("100.1.0.11")
	p2 := ate.Port(t, "port2")
	i2 := top.AddInterface("ateDst").WithPort(p2)
	i2.IPv4().WithAddress("100.1.0.11/24").WithDefaultGateway("100.1.0.1")
	ipv4Flow := ate.Traffic().NewFlow("Ipv4").WithSrcEndpoints(i1).WithDstEndpoints(i2).WithHeaders(ethHeader, ipv4Header).WithFrameSize(512)
	fmt.Println("Pushing topology")
	top.Push(t).StartProtocols(t)
	allFlows := []*ondatra.Flow{ipv4Flow}
	ate.Traffic().Start(t, allFlows...)
}
```