### PR TITLE
Add Factory Reset Operations

### DIFF
--- a/internal/operations/operations.go
+++ b/internal/operations/operations.go
@@ -217,7 +217,7 @@ func SystemTime(ctx context.Context, dut binding.DUT) (time.Time, error) {
 // factoryOS instructs the Target to rollback the OS to the same version as it shipped
 // The gNOI factory_reset scenarios are documented on the Start function here:
 // https://github.com/openconfig/gnoi/blob/master/factory_reset/factory_reset.proto
-func FactoryReset(ctx context.Context, dut binding.DUT, factoryOS bool, zeroFill bool) error {
+func FactoryReset(ctx context.Context, dut binding.DUT, factoryOS, zeroFill bool) error {
 	gnoi, err := FetchGNOI(ctx, dut)
 	if err != nil {
 		return err
@@ -227,10 +227,10 @@ func FactoryReset(ctx context.Context, dut binding.DUT, factoryOS bool, zeroFill
 		ZeroFill:  zeroFill,
 	})
 	if err != nil {
-		return fmt.Errorf("error performing factory reset: %v ", err)
+		return fmt.Errorf("error performing factory reset: %w ", err)
 	}
 	if rpcErr := resp.GetResetError(); rpcErr != nil {
-		return fmt.Errorf("error performing factory reset: %v ", rpcErr)
+		return fmt.Errorf("error performing factory reset: %w ", rpcErr)
 	}
 	return nil
 }

--- a/operations.go
+++ b/operations.go
@@ -190,6 +190,7 @@ func (s *FactoryResetOp) String() string {
 // Operate performs the FactoryReset operation.
 func (s *FactoryResetOp) Operate(t testing.TB) {
 	t.Helper()
+	debugger.ActionStarted(t, "Performing Factory Reset on %s", s.dut)
 	if err := operations.FactoryReset(context.Background(), s.dut, s.factoryOS, s.zeroFill); err != nil {
 		t.Fatalf("Operate(t) on %s: %v", s, err)
 	}

--- a/operations.go
+++ b/operations.go
@@ -149,21 +149,23 @@ func (p *PingOp) Operate(t testing.TB) {
 }
 
 // SystemTime returns system time
-func (o *Operations) SystemTime() (time.Time, error) {
-	return operations.SystemTime(context.Background(), o.dut)
+func (o *Operations) SystemTime(t testing.TB) time.Time {
+	t.Helper()
+	debugger.ActionStarted(t, "Requesting System Time from %s", o.dut)
+	time, err := operations.SystemTime(context.Background(), o.dut)
+	if err != nil {
+		t.Fatalf("SystemTime(t) on %s: %v", o.dut, err)
+	}
+	return time
 }
 
 // NewFactoryReset creates a new Factory Reset Operation.
 // By default the FactoryReset is performed without zero_fill and factory_os.
 func (o *Operations) NewFactoryReset() *FactoryResetOp {
-	return &FactoryResetOp{
-		dut:       o.dut,
-		factoryOS: false,
-		zeroFill:  false,
-	}
+	return &FactoryResetOp{dut: o.dut}
 }
 
-// FactoryResetOp performs a factory reset of the device.
+// FactoryResetOp is a factory reset operation.
 type FactoryResetOp struct {
 	dut       binding.DUT
 	factoryOS bool

--- a/operations.go
+++ b/operations.go
@@ -148,50 +148,51 @@ func (p *PingOp) Operate(t testing.TB) {
 	}
 }
 
-// GetSystemTime returns system time
-func (o *Operations) GetSystemTime() (uint64, error) {
-	return operations.GetSystemTime(context.Background(), o.dut)
+// SystemTime returns system time
+func (o *Operations) SystemTime() (time.Time, error) {
+	return operations.SystemTime(context.Background(), o.dut)
 }
 
-// NewFactoryReset creates a new Factory Reset.
-func (o *Operations) NewFactoryReset() *FactoryReset {
-	return &FactoryReset{
+// NewFactoryReset creates a new Factory Reset Operation.
+// By default the FactoryReset is performed without zero_fill and factory_os.
+func (o *Operations) NewFactoryReset() *FactoryResetOp {
+	return &FactoryResetOp{
 		dut:       o.dut,
-		factoryOs: false,
+		factoryOS: false,
 		zeroFill:  false,
 	}
 }
 
-// FactoryReset enables resetting the device to factory settings
-type FactoryReset struct {
+// FactoryResetOp performs a factory reset of the device.
+type FactoryResetOp struct {
 	dut       binding.DUT
-	factoryOs bool
+	factoryOS bool
 	zeroFill  bool
 }
 
-// WithFactoryOS instructs the Target if it needs to rollback the OS to the same version as it shipped
-func (s *FactoryReset) WithFactoryOS(factoryOs bool) *FactoryReset {
-	s.factoryOs = factoryOs
+// WithFactoryOS instructs the device to rollback the OS to the same version as it shipped.
+func (s *FactoryResetOp) WithFactoryOS(factoryOS bool) *FactoryResetOp {
+	s.factoryOS = factoryOS
 	return s
 }
 
-// WithZeroFill instructs the Target  if it has to zero fill persistent storage state data.
-func (s *FactoryReset) WithZeroFill(zeroFill bool) *FactoryReset {
+// WithZeroFill instructs the device to zero fill persistent storage state data.
+func (s *FactoryResetOp) WithZeroFill(zeroFill bool) *FactoryResetOp {
 	s.zeroFill = zeroFill
 	return s
 }
 
-// String representation of the method
-func (s *FactoryReset) String() string {
+// String representation of the method.
+func (s *FactoryResetOp) String() string {
 	return fmt.Sprintf("FactoryResetOp%+v", *s)
 }
 
 // Operate performs the FactoryReset operation.
-func (s *FactoryReset) Operate(t testing.TB) error {
+func (s *FactoryResetOp) Operate(t testing.TB) {
 	t.Helper()
-	err := operations.FactoryReset(context.Background(), s.dut, s.factoryOs, s.zeroFill)
-	return err
-
+	if err := operations.FactoryReset(context.Background(), s.dut, s.factoryOS, s.zeroFill); err != nil {
+		t.Fatalf("Operate(t) on %s: %v", s, err)
+	}
 }
 
 // NewSetInterfaceState creates a new set interface state operation.

--- a/operations.go
+++ b/operations.go
@@ -15,14 +15,15 @@
 package ondatra
 
 import (
-	"golang.org/x/net/context"
 	"fmt"
 	"io"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/openconfig/gocloser"
+	"golang.org/x/net/context"
+
+	closer "github.com/openconfig/gocloser"
 	"github.com/openconfig/ondatra/binding"
 	"github.com/openconfig/ondatra/internal/debugger"
 	"github.com/openconfig/ondatra/internal/operations"
@@ -145,6 +146,52 @@ func (p *PingOp) Operate(t testing.TB) {
 	if err := operations.Ping(context.Background(), p.dut, p.dest, p.count); err != nil {
 		t.Fatalf("Operate(t) on %s: %v", p, err)
 	}
+}
+
+// GetSystemTime returns system time
+func (o *Operations) GetSystemTime() (uint64, error) {
+	return operations.GetSystemTime(context.Background(), o.dut)
+}
+
+// NewFactoryReset creates a new Factory Reset.
+func (o *Operations) NewFactoryReset() *FactoryReset {
+	return &FactoryReset{
+		dut:       o.dut,
+		factoryOs: false,
+		zeroFill:  false,
+	}
+}
+
+// FactoryReset enables resetting the device to factory settings
+type FactoryReset struct {
+	dut       binding.DUT
+	factoryOs bool
+	zeroFill  bool
+}
+
+// WithFactoryOS instructs the Target if it needs to rollback the OS to the same version as it shipped
+func (s *FactoryReset) WithFactoryOS(factoryOs bool) *FactoryReset {
+	s.factoryOs = factoryOs
+	return s
+}
+
+// WithZeroFill instructs the Target  if it has to zero fill persistent storage state data.
+func (s *FactoryReset) WithZeroFill(zeroFill bool) *FactoryReset {
+	s.zeroFill = zeroFill
+	return s
+}
+
+// String representation of the method
+func (s *FactoryReset) String() string {
+	return fmt.Sprintf("FactoryResetOp%+v", *s)
+}
+
+// Operate performs the FactoryReset operation.
+func (s *FactoryReset) Operate(t testing.TB) error {
+	t.Helper()
+	err := operations.FactoryReset(context.Background(), s.dut, s.factoryOs, s.zeroFill)
+	return err
+
 }
 
 // NewSetInterfaceState creates a new set interface state operation.

--- a/operations_test.go
+++ b/operations_test.go
@@ -644,12 +644,9 @@ func TestSystemTime(t *testing.T) {
 		}, nil
 	}
 	dut := DUT(t, "dut_cisco")
-	op, err := dut.Operations().SystemTime()
-	if err != nil {
-		t.Fatalf("Operatation failed, err %v", err)
-	}
-	if op != time.Unix(0, 12345) {
-		t.Fatalf("Operation  failed, want %v got %v", time.Unix(0, 12345), op)
+	got := dut.Operations().SystemTime(t)
+	if want := time.Unix(0, 12345); want != got {
+		t.Fatalf("Operation failed, want %v got %v", want, got)
 	}
 }
 

--- a/operations_test.go
+++ b/operations_test.go
@@ -639,28 +639,26 @@ func TestKillProcess(t *testing.T) {
 func TestSystemTime(t *testing.T) {
 	initOperationFakes(t)
 	fakeGNOI.SystemTime = func(context.Context, *spb.TimeRequest, ...grpc.CallOption) (*spb.TimeResponse, error) {
-
-		return &spb.TimeResponse{}, nil
+		return &spb.TimeResponse{
+			Time: 12345,
+		}, nil
 	}
-
 	dut := DUT(t, "dut_cisco")
-	op, err := dut.Operations().GetSystemTime()
+	op, err := dut.Operations().SystemTime()
 	if err != nil {
 		t.Fatalf("Operatation failed, err %v", err)
 	}
-	if op != 0 {
-		t.Fatalf("Operation  failed, want 0 got %d", op)
+	if op != time.Unix(0, 12345) {
+		t.Fatalf("Operation  failed, want %v got %v", time.Unix(0, 12345), op)
 	}
 }
 
 func TestFactoryReset(t *testing.T) {
 	initOperationFakes(t)
 	dut := DUT(t, "dut_cisco")
-	err := dut.Operations().NewFactoryReset().Operate(t)
-	if err != nil {
-		t.Fatalf("Operatation failed, err %v", err)
-	}
+	dut.Operations().NewFactoryReset().WithZeroFill(true).WithFactoryOS(true).Operate(t)
 }
+
 func TestKillProcessErrors(t *testing.T) {
 	initOperationFakes(t)
 	fakeGNOI.KillProcessor = func(context.Context, *spb.KillProcessRequest, ...grpc.CallOption) (*spb.KillProcessResponse, error) {


### PR DESCRIPTION
Add Operation for [Factory Reset](https://github.com/openconfig/gnoi/blob/master/factory_reset/factory_reset.proto):
Add Operation to fetch Time with [system.proto](https://github.com/openconfig/gnoi/blob/master/system/system.proto)

Edited Files:
modified: internal/operations/operations.go
modified: operations.go
modified: operations_test.go

UT LOGS:
 go test -v -run TestFactoryReset
=== RUN TestFactoryReset
--- PASS: TestFactoryReset (0.00s)
PASS
ok github.com/openconfig/ondatra 2.453s

go test -v -run TestSystemTime
=== RUN TestSystemTime
--- PASS: TestSystemTime (0.00s)
PASS