### PR TITLE
Harden maybeAnnotateErr

### DIFF
--- a/internal/rawapis/intercept.go
+++ b/internal/rawapis/intercept.go
@@ -69,12 +69,15 @@ func maybeAnnotateErr(err error, req any) error {
 	// Do not annotate the error if:
 	// 1. err is nil: there is no error to annotate
 	// 2. req is nil: there is no request to annotate with
-	// 3. err is not a grpc error: sentinel errors like io.EOF must be preserved
+	// 3. req is not a proto message
+	// 4. err is not a grpc error: sentinel errors like io.EOF must be preserved
 	if err != nil && req != nil {
 		if st, ok := status.FromError(err); ok {
-			reqText := prototext.Format(req.(proto.Message))
-			msg := fmt.Sprintf("error on request {\n%s}: %s", reqText, st.Message())
-			return status.Error(st.Code(), msg)
+			if pm, ok := req.(proto.Message); ok {
+				reqText := prototext.Format(pm)
+				msg := fmt.Sprintf("error on request {\n%s}: %s", reqText, st.Message())
+				return status.Error(st.Code(), msg)
+			}
 		}
 	}
 	return err


### PR DESCRIPTION
This PR changes maybeAnnotateErr to verify that req is a proto message before annotating the error.

Currently, maybeAnnotateErr panics when handling p4rt requests:
```
I1130 01:39:40.399201   18801 p4rt_client.go:242] 'Device(1) Stream(p4rt)' Waiting on Arbitration message (0/1)
panic: interface conversion: *v1.StreamMessageRequest is not protoreflect.ProtoMessage: missing method ProtoReflect

goroutine 117 [running]:
github.com/openconfig/ondatra/internal/rawapis.maybeAnnotateErr({0xfa4c560, 0xc0046fc7d0}, {0xefc3300?, 0xc003185290})
	/nobackup/gob4/FireX_65A0F4D9/go_pkgs/openconfig/ondatra/internal/rawapis/intercept.go:74 +0xa9
github.com/openconfig/ondatra/internal/rawapis.(*annotateErrClient).RecvMsg(0xc005cead20, {0xf016dc0?, 0xc003185230?})
	/nobackup/gob4/FireX_65A0F4D9/go_pkgs/openconfig/ondatra/internal/rawapis/intercept.go:64 +0x78
github.com/p4lang/p4runtime/go/p4/v1.(*p4RuntimeStreamChannelClient).Recv(0xc0011cfe20)
	/nobackup/gob4/jenkins/server/workspace/fp_public_test_sfd/.gocache/pkg/mod/github.com/p4lang/p4runtime@v1.3.0/go/p4/v1/p4runtime.pb.go:4714 +0x4c
github.com/cisco-open/go-p4/p4rt_client.(*P4RTClient).StreamChannelCreate.func1(0xc000056800)
	/nobackup/gob4/jenkins/server/workspace/fp_public_test_sfd/.gocache/pkg/mod/github.com/cisco-open/go-p4@v0.0.0-20220713162912-85fd0d484625/p4rt_client/p4rt_client.go:482 +0x129
created by github.com/cisco-open/go-p4/p4rt_client.(*P4RTClient).StreamChannelCreate
	/nobackup/gob4/jenkins/server/workspace/fp_public_test_sfd/.gocache/pkg/mod/github.com/cisco-open/go-p4@v0.0.0-20220713162912-85fd0d484625/p4rt_client/p4rt_client.go:469 +0x559
```