### PR TITLE
isis l1l2 support

### DIFF
--- a/internal/ate/protocols.go
+++ b/internal/ate/protocols.go
@@ -278,6 +278,8 @@ func (ix *ixATE) addISISProtocols(ifc *opb.InterfaceConfig) error {
 		level = "level1"
 	case opb.ISISConfig_L2:
 		level = "level2"
+	case opb.ISISConfig_L1L2:
+		level = "l1l2"
 	default:
 		return fmt.Errorf("unrecognized level %s", isis.GetLevel())
 	}

--- a/ixnet/isis.go
+++ b/ixnet/isis.go
@@ -75,6 +75,12 @@ func (i *ISIS) WithLevelL2() *ISIS {
 	return i
 }
 
+// WithLevelL1L2 sets the IS-IS level to L1L2.
+func (i *ISIS) WithLevelL1L2() *ISIS {
+	i.pb.Level = opb.ISISConfig_L1L2
+	return i
+}
+
 // WithNetworkTypeBroadcast sets the IS-IS network type to broadcast.
 func (i *ISIS) WithNetworkTypeBroadcast() *ISIS {
 	i.pb.NetworkType = opb.ISISConfig_BROADCAST

--- a/proto/ate.proto
+++ b/proto/ate.proto
@@ -121,6 +121,7 @@ message ISISConfig {
     LEVEL_UNSPECIFIED = 0;
     L1 = 1;
     L2 = 2;
+    L1L2 = 3;
   }
   // The IS-IS level which the ate behaves as.
   Level level = 1;


### PR DESCRIPTION
resolves #77 

How to use:
```
top := ate.Topology().New()
port1 := ate.Port(t, "port1")
ifDut1 := top.AddInterface("port1").WithPort(port1)
isis := ifDut1.ISIS()
isis.WithLevelL1L2()```