### PR TITLE
Add `HOST` as a valid topology device.

### DIFF
--- a/knebind/solver/solver.go
+++ b/knebind/solver/solver.go
@@ -53,6 +53,7 @@ var (
 		tpb.Vendor_JUNIPER:    opb.Device_JUNIPER,
 		tpb.Vendor_NOKIA:      opb.Device_NOKIA,
 		tpb.Vendor_OPENCONFIG: opb.Device_OPENCONFIG,
+		tpb.Vendor_HOST:       opb.Device_VENDOR_UNSPECIFIED,
 	}
 )
 


### PR DESCRIPTION
```
 * (M) knebind/solver/solver.go
   - In current ONDATRA tests it is not possible to reference a `HOST`
     container in the topology since such containers do not have a known
     vendor. This change adds a `HOST` container as a unspecified vendor
     device.
```

The motivation for this change is to support the ability to have arbitrary running containers within a topology that the test needs to interact with.
