### PR TITLE
Make gosnappi handle available via ate.RawAPIs().OTG(t)

### DIFF
--- a/raw/raw.go
+++ b/raw/raw.go
@@ -83,6 +83,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/openconfig/gnoigo"
 	"github.com/openconfig/ondatra/binding"
 	"github.com/openconfig/ondatra/internal/events"
@@ -211,4 +212,15 @@ func (r *ATEAPIs) GNMI(t testing.TB) gpb.GNMIClient {
 		t.Fatalf("Failed to fetch gNMI client for %v: %v", r.ate, err)
 	}
 	return gnmi
+}
+
+// OTG returns the default Open Traffic Generator client for the ATE.
+func (r *ATEAPIs) OTG(t testing.TB) gosnappi.Api {
+	t.Helper()
+	t = events.ActionStarted(t, "Fetching OTG client for %s", r.ate)
+	otg, err := rawapis.FetchOTG(context.Background(), r.ate)
+	if err != nil {
+		t.Fatalf("Failed to fetch OTG client for %v: %v", r.ate, err)
+	}
+	return otg
 }

--- a/raw/raw_test.go
+++ b/raw/raw_test.go
@@ -21,6 +21,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/openconfig/gnoigo"
 	"github.com/openconfig/ondatra/binding"
 	"github.com/openconfig/ondatra/fakebind"
@@ -235,6 +236,31 @@ func TestGNMIATE(t *testing.T) {
 		}
 		if got := ateAPIs.GNMI(t); got != want {
 			t.Errorf("GNMI(t) got %v, want %v", got, want)
+		}
+	})
+}
+
+func TestOTGATE(t *testing.T) {
+	t.Run("error", func(t *testing.T) {
+		wantErr := "bad otg"
+		ate.DialOTGFn = func(context.Context, ...grpc.DialOption) (gosnappi.Api, error) {
+			return nil, errors.New(wantErr)
+		}
+		gotErr := testt.ExpectFatal(t, func(t testing.TB) {
+			ateAPIs.OTG(t)
+		})
+		if !strings.Contains(gotErr, wantErr) {
+			t.Errorf("OTG(t) got err %v, want %v", gotErr, wantErr)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		want := struct{ gosnappi.Api }{}
+		ate.DialOTGFn = func(context.Context, ...grpc.DialOption) (gosnappi.Api, error) {
+			return want, nil
+		}
+		if got := ateAPIs.OTG(t); got != want {
+			t.Errorf("OTG(t) got %v, want %v", got, want)
 		}
 	})
 }


### PR DESCRIPTION
We need to access the gosnappi handle for our internal testing, for example to test features before they become available in Ondatra.
Keysight has a CLA on file.